### PR TITLE
Add big data processing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ or run all tests with `make validate`.
 ## Contributing
 
 We welcome new datasets and improvements. See [CONTRIBUTING.md](CONTRIBUTING.md) for a walkthrough of the submission process and consult the files in the `docs/` directory for more details.
+
+## Processing Very Large Datasets
+
+See `tools/large_dataset_processor.py` for an example using Dask to analyse VCF files over 500 GB. Run `pip install -r requirements.txt` and execute:
+
+```bash
+python tools/large_dataset_processor.py <your.vcf>
+```

--- a/docs/big_data_processing.md
+++ b/docs/big_data_processing.md
@@ -1,0 +1,14 @@
+# Processing Very Large Datasets
+
+The repository includes a utility for analysing extremely large VCF datasets.
+`tools/large_dataset_processor.py` uses [Dask](https://www.dask.org/) to enable
+out-of-core processing so you can handle files exceeding 500 GB on modest
+hardware.
+
+```bash
+pip install -r requirements.txt
+python tools/large_dataset_processor.py path/to/your.vcf
+```
+
+The script counts variant records using a distributed computation graph. You can
+pass glob patterns to process multiple shards in parallel.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,5 @@
 The DataHub provides a curated archive of cardiovascular omics datasets used in HeartBioPortal. Each dataset is stored in its own folder under `public/` or `private/` and includes metadata and provenance files that follow JSON schemas.
 
 Use the navigation menu to learn how to submit new data and to browse the schema reference.
+
+See [Processing Very Large Datasets](big_data_processing.md) for analysing VCF files exceeding 500 GB using Dask.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,4 +3,5 @@ nav:
   - Overview: index.md
   - Submitting Data: submitting.md
   - Schema Reference: schema_reference.md
+  - Processing Very Large Datasets: big_data_processing.md
   - FAQ: faq.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jsonschema
 pytest
 jsonschema2md
 PyGithub
+dask

--- a/tests/test_large_processor.py
+++ b/tests/test_large_processor.py
@@ -1,0 +1,13 @@
+import subprocess
+from pathlib import Path
+
+
+def test_variant_count():
+    vcf = Path('public/example_fh_vcf/variant.vcf')
+    result = subprocess.run(
+        ['tools/large_dataset_processor.py', str(vcf)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert 'Total variant records: 1' in result.stdout

--- a/tools/large_dataset_processor.py
+++ b/tools/large_dataset_processor.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Utility for analyzing large VCF datasets using Dask.
+
+This script demonstrates how to process variant call format (VCF) files that may
+exceed hundreds of gigabytes in size. It uses Dask's lazy computation model to
+enable out-of-core processing so that the data can be analysed on machines with
+limited memory.
+"""
+import argparse
+import dask.bag as db
+from typing import Union
+
+
+def count_variants(vcf_path: Union[str, list[str]]) -> int:
+    """Count variant records in a VCF file.
+
+    Parameters
+    ----------
+    vcf_path: str or list
+        Path(s) to VCF file(s). Wildcards are allowed to process sharded data.
+    Returns
+    -------
+    int
+        Number of variant records found.
+    """
+    lines = db.read_text(vcf_path)
+    variant_lines = lines.filter(lambda x: not x.startswith('#'))
+    return variant_lines.count().compute()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Process large VCF datasets using Dask")
+    parser.add_argument("vcf", help="Path to the VCF file or pattern")
+    args = parser.parse_args(argv)
+
+    count = count_variants(args.vcf)
+    print(f"Total variant records: {count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `large_dataset_processor.py` for Dask-based processing of huge VCF files
- describe large dataset processing in README and docs
- document the new script in mkdocs navigation
- add test for the new processor
- include `dask` in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dask')*

------
https://chatgpt.com/codex/tasks/task_e_6888ffb33c6c8328b84182eb4eef3ab0