### PR TITLE
Add dataset listing script and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: validate docs
+
+validate:
+	pytest -q
+
+docs:
+	python scripts/gen_schema_docs.py
+	mkdocs build

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ HeartBioPortal DataHub is a version-controlled collection of cardiovascular omic
 ```bash
 git clone <repo-url>
 cd DataHub
+pip install -r requirements.txt
 make validate
 # or using docker
 docker compose up validation
@@ -32,6 +33,12 @@ Datasets are organised under `public/` for open data or `private/` for embargoed
 ```
 
 The JSON schemas that describe these files live under `schemas/` and are also rendered in the documentation.
+
+You can list available datasets using:
+
+```bash
+tools/list_datasets.py
+```
 
 ## Validation
 

--- a/tests/test_list_datasets.py
+++ b/tests/test_list_datasets.py
@@ -1,0 +1,7 @@
+import subprocess
+
+def test_list_includes_example():
+    result = subprocess.run(['tools/list_datasets.py'], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'example_fh_vcf' in result.stdout
+

--- a/tools/list_datasets.py
+++ b/tools/list_datasets.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""List available dataset IDs and titles."""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+def iterate_datasets(base: Path):
+    for meta_path in base.glob('*/metadata.json'):
+        with meta_path.open() as fh:
+            data = json.load(fh)
+        yield data.get('dataset_id', meta_path.parent.name), data.get('title', '')
+
+def main() -> int:
+    roots = [Path('public'), Path('private')]
+    for root in roots:
+        if not root.exists():
+            continue
+        for ds_id, title in iterate_datasets(root):
+            print(f"{ds_id}\t{title}")
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Makefile with a `validate` task to run the tests
- add `tools/list_datasets.py` for listing dataset IDs
- document dependency installation and dataset listing in the README
- test new script via `tests/test_list_datasets.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dask')*

------
https://chatgpt.com/codex/tasks/task_e_688980004cc88328a24a1c40a401de33