### PR TITLE
Improve README and add validation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,98 @@
 # HeartBioPortal DataHub
 
-HeartBioPortal DataHub is a version-controlled collection of cardiovascular omics datasets. Each dataset includes standardised metadata and provenance information so that analyses can be reproduced and referenced.
+HeartBioPortal DataHub is the canonical, version-controlled collection of cardiovascular omics datasets used across the HeartBioPortal ecosystem. Each contribution is reviewed, validated, and stored alongside machine-readable metadata so that downstream analyses can be reproduced, cited, and continuously improved.
 
-## Quick Start
+## Key features
+
+- **Curated data catalogue** – each dataset is stored in its own folder with descriptive metadata and provenance information.
+- **Schema-driven validation** – JSON Schemas under `schemas/` ensure that metadata and provenance files follow a consistent structure.
+- **Reproducible tooling** – helper scripts, automated tests, and MkDocs documentation make it easy to validate and explore datasets locally.
+- **Open collaboration** – submissions are tracked in git, with Git LFS support for large binary artefacts and a transparent review process.
+
+## Repository layout
+
+| Path | Description |
+| --- | --- |
+| `public/` | Open datasets available to all users. |
+| `private/` | Embargoed submissions that require restricted access. |
+| `schemas/` | JSON Schemas describing dataset metadata and provenance formats. |
+| `docs/` | MkDocs documentation source, including schema reference pages. |
+| `tools/` | Command-line utilities for listing, validating, and processing datasets. |
+| `tests/` | Automated validation tests executed via `pytest`. |
+
+## Prerequisites
+
+1. Install [Git LFS](https://git-lfs.github.com/) before cloning the repository:
+   ```bash
+   git lfs install
+   ```
+2. Ensure you have Python 3.9+ available for running the validation tooling.
+3. Optional: install Docker if you prefer containerised validation.
+
+## Quick start
 
 ```bash
 git clone <repo-url>
 cd DataHub
 pip install -r requirements.txt
-make validate
+make validate          # run automated tests locally
+
 # or using docker
 docker compose up validation
 ```
 
-## Git Large File Storage
+Once dependencies are installed, run `tools/list_datasets.py` to explore the catalogue of available datasets.
 
-This repository uses [Git LFS](https://git-lfs.github.com/) for storing large binary datasets. Install Git LFS before cloning:
+## Working with datasets
 
-```bash
-git lfs install
-```
-
-## Dataset Layout
-
-Datasets are organised under `public/` for open data or `private/` for embargoed submissions. A typical dataset directory contains:
+Every dataset lives under either `public/` or `private/` and follows a consistent layout:
 
 ```
 <dataset>/
-  metadata.json      # descriptive metadata
-  provenance.json    # processing provenance
-  data files...
+  metadata.json      # descriptive metadata aligned with schemas/metadata.schema.json
+  provenance.json    # processing provenance aligned with schemas/prov.schema.json
+  data/ or other files...
 ```
 
-The JSON schemas that describe these files live under `schemas/` and are also rendered in the documentation.
+Use the [`public/example_fh_vcf`](public/example_fh_vcf) folder as a template when creating a new submission. The schemas referenced above are also rendered into human-readable documentation (see [Documentation](#documentation)).
 
-You can list available datasets using:
+### Submission workflow
 
-```bash
-tools/list_datasets.py
-```
+1. Fork the repository and create a feature branch for your dataset.
+2. Add your dataset folder under `public/` or `private/` with the required JSON files and supporting artefacts.
+3. Validate the dataset locally (see [Validation](#validation-and-quality-assurance)).
+4. Open a pull request describing the dataset, methodologies, and any licensing considerations. A reviewer will inspect the metadata, provenance, and validation output before merge.
 
-## Validation
+## Validation and quality assurance
 
-Use the helper script to check a dataset before opening a pull request:
+Use the helper CLI to validate a dataset before submitting a pull request:
 
 ```bash
 tools/hbp-validate public/example_fh_vcf
 ```
 
-or run all tests with `make validate`.
+Running `make validate` executes the full `pytest` suite, including schema validation and regression checks. For complex workflows or very large files, consult [docs/validation.md](docs/validation.md) for detailed guidance on troubleshooting failures, working with Git LFS assets, and interpreting validation output.
 
-## Contributing
+## Documentation
 
-We welcome new datasets and improvements. See [CONTRIBUTING.md](CONTRIBUTING.md) for a walkthrough of the submission process and consult the files in the `docs/` directory for more details.
-
-## Processing Very Large Datasets
-
-See `tools/large_dataset_processor.py` for an example using Dask to analyse VCF files over 500 GB. Run `pip install -r requirements.txt` and execute:
+The documentation site is built with [MkDocs](https://www.mkdocs.org/). Generate the schema reference pages and build the site locally with:
 
 ```bash
-python tools/large_dataset_processor.py <your.vcf>
+make docs
 ```
+
+This command runs `python scripts/gen_schema_docs.py` to create Markdown documentation from the JSON Schemas before compiling the MkDocs site in `site/`. Published documentation includes the submission workflow, schema reference, large dataset processing tips, FAQ, and validation guides.
+
+## Helpful tooling
+
+- `tools/list_datasets.py` – list registered datasets and their metadata summary.
+- `tools/hbp-validate` – validate a dataset directory against the schemas and integrity checks.
+- `tools/large_dataset_processor.py` – example pipeline that demonstrates analysing >500 GB VCF files using Dask.
+
+## Contributing and support
+
+We welcome new datasets, bug fixes, and tooling improvements. Review [CONTRIBUTING.md](CONTRIBUTING.md) for the full submission checklist and coding standards. Questions can be raised via GitHub issues or by contacting the HeartBioPortal maintainers.
+
+## License
+
+HeartBioPortal DataHub is released under the terms of the [MIT License](LICENSE).

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,69 @@
+# Validation Guide
+
+Validating datasets before submission keeps the DataHub consistent and prevents broken metadata from entering production. This guide explains the available validation tooling, common error messages, and best practices for resolving issues.
+
+## When to run validation
+
+- **During dataset preparation** – run validation locally as you populate `metadata.json` and `provenance.json` to catch schema violations early.
+- **Before opening a pull request** – include the validation output in your PR description so reviewers can confirm the dataset passes automated checks.
+- **After rebasing or merging** – rerun validation if your branch picks up changes to the schemas or validation tests.
+
+## Validation tooling
+
+### `tools/hbp-validate`
+
+This is the quickest way to check a single dataset directory against the repository schemas and integrity rules.
+
+```bash
+tools/hbp-validate public/example_fh_vcf
+```
+
+Key features:
+
+- Loads the dataset metadata and provenance files and validates them against the JSON Schemas under `schemas/`.
+- Ensures required files are present and checksums (where provided) match the accompanying data.
+- Provides clear error messages with JSON pointer paths to help locate problematic fields.
+
+> **Tip:** Use the `--fix` flag (when available) to auto-format JSON files with consistent ordering.
+
+### `make validate`
+
+Running `make validate` executes the full `pytest` suite defined in the repository. This includes schema validation plus any regression or integration tests implemented under `tests/`.
+
+```bash
+make validate
+```
+
+Use this command before submitting a pull request or when working on validation tooling to ensure nothing regresses.
+
+### Docker-based validation
+
+For teams that prefer containerised tooling, the repository includes a Docker Compose service that mirrors the local workflow:
+
+```bash
+docker compose up validation
+```
+
+This is helpful when contributors do not want to manage Python dependencies on their host machine. The validation logs will stream to the terminal; exit the service with `Ctrl+C` when complete.
+
+## Troubleshooting common issues
+
+| Error message | Meaning | Resolution |
+| --- | --- | --- |
+| `is not valid under any of the given schemas` | The JSON file does not match the schema definition. | Inspect the pointer provided in the error message and cross-reference with `schemas/metadata.schema.json` or `schemas/prov.schema.json`. |
+| `file not found` | A file referenced in your metadata is missing from the dataset folder. | Ensure all declared artefacts are committed with Git LFS (for large files) and paths are correct. |
+| `checksum mismatch` | The provided checksum does not match the file contents. | Recalculate the checksum (e.g., `shasum -a 256 <file>`) and update the metadata. |
+| `Additional properties are not allowed` | Extra fields are present in the JSON document. | Remove the unrecognised properties or propose schema updates in a separate pull request. |
+
+If a failure message is unclear, run `pytest -k <dataset-name> -vv` to see the full traceback and context.
+
+## Best practices
+
+- **Commit JSON files in UTF-8 without trailing whitespace** to avoid formatting churn.
+- **Store large binary artefacts with Git LFS** and confirm the `.gitattributes` entry is correct.
+- **Document preprocessing steps in `provenance.json`**, including tool versions and command-line arguments.
+- **Automate validation in CI** by reusing the `make validate` target in your preferred pipeline.
+
+## Need help?
+
+Open a GitHub issue with the validation command you ran, the error output, and a link to your branch. Maintainers are happy to help diagnose stubborn issues or extend the validation tooling.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: HeartBioPortal DataHub
 nav:
   - Overview: index.md
   - Submitting Data: submitting.md
+  - Validation Guide: validation.md
   - Schema Reference: schema_reference.md
   - Processing Very Large Datasets: big_data_processing.md
   - FAQ: faq.md


### PR DESCRIPTION
## Summary
- expand the README with repository overview, submission workflow, validation, and documentation details
- add a dedicated validation guide to the MkDocs documentation and expose it in the navigation

## Testing
- make validate

------
https://chatgpt.com/codex/tasks/task_e_68d47ec5dcf48328830a30873ad5dd24